### PR TITLE
Performance and memory improvements, caching

### DIFF
--- a/astree_analyzer/parser/parse.py
+++ b/astree_analyzer/parser/parse.py
@@ -156,6 +156,7 @@ class ASTSerializer:
         if subtrees is None:
             subtrees = []
 
+        self.anon_map.clear()
         subtree = self._serialize_node(node)
         subtrees.append(subtree)
 

--- a/astree_analyzer/parser/parse.py
+++ b/astree_analyzer/parser/parse.py
@@ -39,15 +39,17 @@ clang.cindex.Config.set_library_file(library_file)
 class ASTSerializer:
     def __init__(self, primitive_replacements=PRIMITICE_REPLACEMENTS):
         self.primitive_replacements = primitive_replacements
-        self.node_cache = {}
-        self.anon_map = {}
 
 
     def extract_subrees_for_file(self, filepath):
+        self.node_cache = {}
+        self.anon_map = {}
         ast = parse_to_ast(filepath)
         subtrees = self._extract_subtrees(ast)
         self.node_cache.clear()
         self.anon_map.clear()
+        del self.node_cache
+        del self.anon_map
         return subtrees
 
 

--- a/astree_analyzer/parser/parse.py
+++ b/astree_analyzer/parser/parse.py
@@ -4,89 +4,178 @@ import clang.cindex
 import hashlib
 from collections import Counter
 from pathlib import Path
-from . import PROJECT_ROOT
 
 # Change path as necessary. This is for Mac.
-
+PROJECT_ROOT = Path(__file__).parent.parent.parent
 if platform.system() ==  "Windows":
     library_file = str(PROJECT_ROOT / "libs/windows/libclang.dll")
 else:
     library_file = '/opt/homebrew/opt/llvm/lib/libclang.dylib'
 
 
+IDENTIFIER_KINDS = {
+    clang.cindex.CursorKind.VAR_DECL,
+    clang.cindex.CursorKind.PARM_DECL,
+    clang.cindex.CursorKind.FIELD_DECL,
+    clang.cindex.CursorKind.FUNCTION_DECL,
+    clang.cindex.CursorKind.DECL_REF_EXPR
+}
+
+# Extended beyond just primitives
+PRIMITICE_REPLACEMENTS = {
+    clang.cindex.CursorKind.INTEGER_LITERAL: '0',
+    clang.cindex.CursorKind.FLOATING_LITERAL: '0.0',
+    clang.cindex.CursorKind.CHARACTER_LITERAL: "'*'",
+    clang.cindex.CursorKind.CXX_BOOL_LITERAL_EXPR: 'false',
+    clang.cindex.CursorKind.STRING_LITERAL: '"str"' # not primitive, add more as needed
+}
+
+BINARY_OPERATORS = {'+', '-', '*', '/', '%', '<', '>', '<=', '>=', '==', '!=', '&', '|', '^', '&&', '||', '=', '+=', '-=', '*=', '/=', '%=', '&=', '|=', '^='}
+UNARY_OPERATORS = {'++', '--', '+', '-', '!', '~'}
+
 clang.cindex.Config.set_library_file(library_file)
 
-def serialize_node(node, anon_map=None):
-    if anon_map is None:
-        anon_map = {}
-    identifier_kinds = {
-        clang.cindex.CursorKind.VAR_DECL,
-        clang.cindex.CursorKind.PARM_DECL,
-        clang.cindex.CursorKind.FIELD_DECL,
-        clang.cindex.CursorKind.FUNCTION_DECL,
-        clang.cindex.CursorKind.DECL_REF_EXPR
-    }
 
-    # Extended beyond just primitives
-    primitive_replacements = {
-        clang.cindex.CursorKind.INTEGER_LITERAL: '0',
-        clang.cindex.CursorKind.FLOATING_LITERAL: '0.0',
-        clang.cindex.CursorKind.CHARACTER_LITERAL: "'*'",
-        clang.cindex.CursorKind.CXX_BOOL_LITERAL_EXPR: 'false',
-        clang.cindex.CursorKind.STRING_LITERAL: '"str"' # not primitive, add more as needed
-    }
+class ASTSerializer:
+    def __init__(self, primitive_replacements=PRIMITICE_REPLACEMENTS):
+        self.primitive_replacements = primitive_replacements
+        self.node_cache = {}
+        self.anon_map = {}
 
-    if node.kind in identifier_kinds:
-        if node.spelling not in anon_map:
-            anon_map[node.spelling] = f"var_{len(anon_map)}"
-        node_rep = f"{anon_map[node.spelling]}_{node.type.spelling}"
-        if '[' in node.type.spelling and ']' in node.type.spelling:
-            base_type, subscript = node.type.spelling.split('[', 1)
-            subscript = 0  # interpret as an integer literal for anonymization
-            node_rep = f"{anon_map[node.spelling]}_{base_type}[{subscript}]"
-    elif node.kind in primitive_replacements:
-        node_rep = primitive_replacements[node.kind]
-    else:
-        node_rep = str(node.kind)
 
-    if node.kind == clang.cindex.CursorKind.BINARY_OPERATOR:
-        tokens = list(node.get_tokens())
-        operator = None
-        for token in tokens:
-            if token.spelling in {'+', '-', '*', '/', '%', '<', '>', '<=', '>=', '==', '!=', '&', '|', '^', '&&', '||', '=', '+=', '-=', '*=', '/=', '%=', '&=', '|=', '^='}:
-                operator = token.spelling
-                break
-        if operator:
-            node_rep = f"{node_rep}_{operator}"
-    elif node.kind == clang.cindex.CursorKind.UNARY_OPERATOR:
-        tokens = list(node.get_tokens())
-        if tokens:
-            if tokens[0].spelling in {'++', '--', '+', '-', '!', '~'}:
-                operator = tokens[0].spelling + '_pre'
-            elif tokens[-1].spelling in {'++', '--', '+', '-', '!', '~'}:
-                operator = tokens[-1].spelling + '_post'
+    def extract_subrees_for_file(self, filepath):
+        ast = parse_to_ast(filepath)
+        subtrees = self._extract_subtrees(ast)
+        self.node_cache.clear()
+        self.anon_map.clear()
+        return subtrees
+
+
+    def _get_node_cache(self, node):
+        node_id = node.hash
+        node_data = self.node_cache.get(node_id)
+        if node_data is None:
+            node_data = {}
+            self.node_cache[node_id] = node_data
+        return node_data
+
+    def _get_node_children(self, node):
+        node_data = self._get_node_cache(node)
+        children = node_data.get("children")
+        if children is None:
+            children = list(node.get_children())
+            node_data["children"] = children
+        return children
+
+    def _serialize_node(self, node):
+        node_data = self._get_node_cache(node)
+        node_kind = node_data.get("kind")
+        if node_kind is None:
+            node_kind = node.kind
+            node_data["kind"] = node_kind
+
+        if node_kind in IDENTIFIER_KINDS:
+            node_spelling = node_data.get("spelling")
+            if node_spelling is None:
+                node_spelling = node.spelling
+                node_data["spelling"] = node_spelling
+
+            anon_name = self.anon_map.get(node_spelling)
+            node_type_spelling = node.type.spelling
+
+            if anon_name is None:
+                anon_name = f"var_{len(self.anon_map)}"
+                self.anon_map[node_spelling] = anon_name
+
+            node_rep = f"{anon_name}_{node_type_spelling}"
+
+            index = node_type_spelling.find('[')
+            if index != -1:
+                base_type = node_type_spelling[:index]
+                subscript = node_type_spelling[index+1:]
+                # base_type, subscript = node_type_spelling.split('[', 1)
+                subscript = 0  # interpret as an integer literal for anonymization
+                node_rep = f"{anon_name}_{base_type}[{subscript}]"
+        else:
+            # if the representation does not depend on the anonimization data
+            # it can be cached/read from cache
+            cahced_node_rep = node_data.get("node_rep")
+
+            if cahced_node_rep is None:
+                node_rep = self.primitive_replacements.get(node_kind)
+                if node_rep is None:
+                    node_rep = str(node_kind)
+
+                if node_kind == clang.cindex.CursorKind.BINARY_OPERATOR:
+                    operator = None
+                    for token in node.get_tokens():
+                        token_spelling = token.spelling
+                        if token_spelling in BINARY_OPERATORS:
+                            operator = token_spelling
+                            break
+                    if operator:
+                        node_rep = f"{node_rep}_{operator}"
+                elif node_kind == clang.cindex.CursorKind.UNARY_OPERATOR:
+                    first_token, last_token = _get_fisrt_and_last_tokens(node)
+                    if first_token:
+                        first_token_spelling = first_token.spelling
+                        last_token_spelling = last_token.spelling
+                        if first_token_spelling in UNARY_OPERATORS:
+                            operator = first_token_spelling + '_pre'
+                        elif last_token_spelling in UNARY_OPERATORS:
+                            operator = last_token_spelling + '_post'
+                        else:
+                            operator = first_token_spelling
+                        node_rep = f"{node_rep}_{operator}"
+                elif node_kind == clang.cindex.CursorKind.CALL_EXPR:
+                    node_rep = f"{node_rep}_{node.displayname}"
+
+                node_data["node_rep"] = node_rep
             else:
-                operator = tokens[0].spelling
-            node_rep = f"{node_rep}_{operator}"
-    elif node.kind == clang.cindex.CursorKind.CALL_EXPR:
-        node_rep = f"{node_rep}_{node.displayname}"
-    elif node.kind == clang.cindex.CursorKind.ARRAY_SUBSCRIPT_EXPR:
-        array_base = serialize_node(list(node.get_children())[0], anon_map)
-        subscript = serialize_node(list(node.get_children())[1], anon_map)
-        node_rep = f"{array_base}[{subscript}]"
+                node_rep = cahced_node_rep
 
-    children_rep = [serialize_node(child, anon_map) for child in node.get_children() if node.kind != clang.cindex.CursorKind.ARRAY_SUBSCRIPT_EXPR]
-    return f"{node_rep}({','.join(children_rep)})" if children_rep else node_rep
 
-# Gets all subtrees with node parameter as root
-def extract_subtrees(node, subtrees=None):
-    if subtrees is None:
-        subtrees = []
-    subtree = serialize_node(node)
-    subtrees.append(subtree)
-    for child in node.get_children():
-        extract_subtrees(child, subtrees)
-    return subtrees
+        if node_kind == clang.cindex.CursorKind.ARRAY_SUBSCRIPT_EXPR:
+            children_iterator = node.get_children()
+            first_child = next(children_iterator, None)
+            second_child = next(children_iterator, None)
+
+            array_base = self._serialize_node(first_child)
+            subscript = self._serialize_node(second_child)
+            node_rep = f"{array_base}[{subscript}]"
+            children_rep = []
+        else:
+            children = self._get_node_children(node)
+            children_rep = [self._serialize_node(child) for child in children]
+
+        return f"{node_rep}({','.join(children_rep)})" if children_rep else node_rep
+
+
+    # Gets all subtrees with node parameter as root
+    def _extract_subtrees(self, node, subtrees=None):
+        if subtrees is None:
+            subtrees = []
+
+        subtree = self._serialize_node(node)
+        subtrees.append(subtree)
+
+        children = self._get_node_children(node)
+
+        for child in children:
+            self._extract_subtrees(child, subtrees)
+        return subtrees
+
+
+def _get_fisrt_and_last_tokens(node):
+    tokens_iterator = node.get_tokens()
+    first_token = next(tokens_iterator, None)
+    last_token = first_token  # Initialize last_token in case there's only one
+    if not first_token:
+        return first_token, last_token
+
+    for last_token in tokens_iterator:  # This will end with the last token
+        pass
+    return first_token, last_token
 
 def hash_subtree(subtree):
     return hashlib.sha256(subtree.encode('utf-8')).hexdigest()
@@ -221,9 +310,8 @@ def parse(input_path: str, output_dir: str):
     """
     TODO write docstring
     """
-
-    ast = parse_to_ast(input_path)
-    subtrees = extract_subtrees(ast)
+    serializer = ASTSerializer()
+    subtrees = serializer.extract_subrees_for_file(input_path)
 
     # Create a mapping between serialized and deserialized subtrees
     subtree_map = {subtree: print_tree(deserialize_subtree(subtree)) for subtree in subtrees}

--- a/astree_analyzer/parser/parse.py
+++ b/astree_analyzer/parser/parse.py
@@ -154,18 +154,21 @@ class ASTSerializer:
 
 
     # Gets all subtrees with node parameter as root
-    def _extract_subtrees(self, node, subtrees=None):
-        if subtrees is None:
-            subtrees = []
+    def _extract_subtrees(self, root):
+        subtrees = []
+        stack = [root]
 
-        self.anon_map.clear()
-        subtree = self._serialize_node(node)
-        subtrees.append(subtree)
+        while stack:
+            node = stack.pop()
 
-        children = self._get_node_children(node)
+            self.anon_map.clear()
+            subtree = self._serialize_node(node)
+            subtrees.append(subtree)
 
-        for child in children:
-            self._extract_subtrees(child, subtrees)
+            children = self._get_node_children(node)
+
+            for child in children:
+                stack.append(child)
         return subtrees
 
 

--- a/astree_analyzer/parser/projectAnalyzer.py
+++ b/astree_analyzer/parser/projectAnalyzer.py
@@ -1,86 +1,143 @@
 import pstats
-from parse import *
+import datetime
+from typing import Optional
+from parser.parse import *
 import os
 import time
 import pickle
 import cProfile
 from pathlib import Path
 
-# Start timing
-start_time = time.time()
-print("Start:", start_time)
+
 
 profiler = cProfile.Profile()
 
-profile = False
+def _convert_time(timestamp):
+    date_time = datetime.datetime.fromtimestamp(timestamp)  # Convert to a datetime object
+    return  date_time.strftime('%Y-%m-%d %H:%M:%S')
 
-def process_directory(directory):
+
+def process_directory(intput_dir, output, include_human_readable=False):
+    # Start timing
+    start_time = time.time()
+    print("Start:", _convert_time(start_time))
+
     all_subtrees = []
+
+    for filepath in Path(intput_dir).rglob('*.c'):
+        subtrees = process_file(filepath)
+        all_subtrees.extend(subtrees)
+
+    _write_subtrees(output, subtrees, include_human_readable=include_human_readable)
+
+    end_time = time.time()
+    print("End:", _convert_time(end_time))
+
+    # Print the elapsed time
+    elapsed_time = end_time - start_time
+    print(f"Time elapsed: {elapsed_time:.2f} seconds")
+
+
+def process_file(filepath: Path, output: Optional[Path]=None, include_human_readable: Optional[bool]=False, profile: Optional[bool]=False):
     serializer = ASTSerializer()
-    for file_path in Path(directory).rglob('*.c'):
-        try:
-            if profile:
-                profiler.enable()
-            filename = file_path.name
-            print(f"Parsing {filename}")
-            file_start_time = time.time()
-            subtrees = serializer.extract_subrees_for_file(file_path)
-            if profile:
-                profiler.disable()
-                stats = pstats.Stats(profiler).sort_stats('cumtime')
+    filename = filepath.name
+
+    try:
+        if profile:
+            profiler.enable()
+        print(f"Parsing {filename}")
+        file_start_time = time.time()
+        subtrees = serializer.extract_subrees_for_file(filepath)
+        if profile:
+            profiler.disable()
+            # Optionally, save the stats for later analysis:
+            stats = pstats.Stats(profiler).sort_stats("cumtime")
+            if output:
+                output_dir = output.parent
+                stats.dump_stats(output_dir / "profile_results.prof")
+            else:
                 stats.print_stats()
-                # Optionally, save the stats for later analysis:
-                stats.dump_stats('profile_results.prof')
-            file_end_time = time.time()
-            print(file_end_time - file_start_time)
-            all_subtrees.extend(subtrees)
-            print("Completed:", filename)
-        except Exception as e:
-            print(f"Error processing {filename}: {e}")
-    return all_subtrees
 
-# Load any existing subtrees if available
-temp_file = 'subtrees_temp.pkl'
-all_subtrees = []
-if os.path.exists(temp_file):
-    with open(temp_file, 'rb') as f:
-        all_subtrees = pickle.load(f)
+        file_end_time = time.time()
+        print(file_end_time - file_start_time)
+        if output:
+            _write_subtrees(output, subtrees, include_human_readable=include_human_readable)
 
-directory = './git'  # Update with your directory path
+        print("Completed:", filename)
+        return subtrees
 
-try:
-    new_subtrees = process_directory(directory)
-    all_subtrees.extend(new_subtrees)
+    except Exception as e:
+        print(f"Error processing {filename}: {e}")
+        raise
 
-    # Create a mapping between serialized and deserialized subtrees
-    subtree_map = {subtree: print_tree(deserialize_subtree(subtree)) for subtree in all_subtrees}
-    subtree_counter = count_subtrees(all_subtrees)
 
-    # Write to CSV
-    with open('subtreesGit.csv', 'w', newline='') as csvfile:
-        fieldnames = ['Hash', 'Count', 'Human Readable Expression', 'Serialized Subtree', 'Deserialized Tree']
-        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+def _write_subtrees(output: Path, subtrees: list, include_human_readable: Optional[bool]=False):
+    try:
 
-        writer.writeheader()
-        for subtree, count in subtree_counter.items():
-            hash_val = hash_subtree(subtree)
-            deserialized_tree = subtree_map[subtree]
-            human_readable_expression = tree_to_expression(deserialize_subtree(subtree))
-            writer.writerow({
-                'Hash': hash_val,
-                'Count': count,
-                'Human Readable Expression': human_readable_expression,
-                'Serialized Subtree': subtree,
-                'Deserialized Tree': deserialized_tree
-            })
-except Exception as e:
-    print(f"An error occurred: {e}")
-    with open(temp_file, 'wb') as f:
-        pickle.dump(all_subtrees, f)
+        print("Writing to CSV")
+        if not output.parent.is_dir():
+            output.mkdir(parents=True)
 
-# End timing
-end_time = time.time()
+        # Create a mapping between serialized and deserialized subtrees
+        subtree_map = {}
+        if include_human_readable:
+            subtree_map = {subtree: print_tree(deserialize_subtree(subtree)) for subtree in subtrees}
 
-# Print the elapsed time
-elapsed_time = end_time - start_time
-print(f"Time elapsed: {elapsed_time:.2f} seconds")
+        subtree_counter = count_subtrees(subtrees)
+
+        # Write to CSV
+        output.write_text("")  # Clears the file
+
+        if include_human_readable:
+            fieldnames = ['Hash', 'Count', 'Human Readable Expression', 'Serialized Subtree', 'Deserialized Tree']
+        else:
+            fieldnames = ['Hash', 'Count', 'Serialized Subtree']
+
+
+        with open(output, "a", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+            for subtree, count in subtree_counter.items():
+                hash_val = hash_subtree(subtree)
+
+                if include_human_readable:
+                    deserialized_tree = subtree_map[subtree]
+                    human_readable_expression = tree_to_expression(deserialize_subtree(subtree))
+                    writer.writerow({
+                        'Hash': hash_val,
+                        'Count': count,
+                        'Human Readable Expression': human_readable_expression,
+                        'Serialized Subtree': subtree,
+                        'Deserialized Tree': deserialized_tree
+                    })
+                else:
+                    writer.writerow({
+                        'Hash': hash_val,
+                        'Count': count,
+                        'Serialized Subtree': subtree,
+                    })
+
+        print(f"Reuslts saved to {output.absolute().resolve()}")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        temp_file = 'subtrees_temp.pkl'
+        with open(temp_file, 'wb') as f:
+            pickle.dump(subtrees, f)
+
+
+
+def __main__():
+    directory = "./git"
+    output = "../../output/subtreesGit.csv"
+    # Load any existing subtrees if available
+
+    temp_file = 'subtrees_temp.pkl'
+    all_subtrees = []
+    if os.path.exists(temp_file):
+        with open(temp_file, 'rb') as f:
+                all_subtrees = pickle.load(f)
+
+    if all_subtrees:
+        _write_subtrees(output, all_subtrees, True)
+    else:
+        process_directory(Path(directory), output,)

--- a/astree_analyzer/tools/cli.py
+++ b/astree_analyzer/tools/cli.py
@@ -1,5 +1,6 @@
+from pathlib import Path
 import click
-from parser.parse import parse  # Replace with your actual function
+from parser.projectAnalyzer import process_file, process_directory
 
 
 @click.group()
@@ -8,11 +9,29 @@ def ast():
     pass
 
 @ast.command()
-@click.argument('input_file', type=click.Path(exists=True))
-@click.argument('output_dir', type=click.Path(exists=True))
-def analyze(input_file, output_dir):
+@click.argument("input_file", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path())
+@click.option("--human-readable", is_flag=True, default=False, help="Include human-readable columns in the output.")
+@click.option("--profile", is_flag=True, default=False, help="Profile using cProfile")
+def parse_file(input_file, output_file, human_readable, profile):
     """Analyze the given INPUT_FILE."""
-    result = parse(input_file, output_dir)
-    click.echo(result)
+    process_file(
+        Path(input_file),
+        Path(output_file),
+        include_human_readable=human_readable,
+        profile=profile
+    )
+
+@ast.command
+@click.argument("input_dir", type=click.Path(exists=True))
+@click.argument("output_file",  type=click.Path())
+@click.option("--human-readable", is_flag=True, default=False, help="Include human-readable columns in the output.")
+def parse_dir(input_dir, output_file ,human_readable):
+    process_directory(
+        Path(input_dir),
+        Path(output_file),
+        include_human_readable=human_readable,
+    )
+
 
 ast()


### PR DESCRIPTION
Since a lot of the nodes are processed multiple times (or even over 100 times), and only `anon_map` and serialization of identifier are different, we can cache `node_rep` and other data, including a list of nodes children for each processed node.
This significantly improves the performance. It also looks like `node.kind` and `node.spelling` are relatively expensive lookups, so cache that data too.

On my machine, on master, serialization of `abspath.c` (git's first file) takes around 12.5 seconds. On this branch, just under 4 second. It did not take over 15 seconds to serialize any of the files on this branch, while on master it took over 30 seconds in some case.



Output of `add.c` looks identical to the old one.

Storing all subtrees in one list `all_subtrees` caused the memory usage to gradually increase. On my machine, it reached around 6GB. Dump all subtrees to temp, then combine the ones that have the same hash at the end. Use multithreading to write to the temp file while parsing.

Some refactoring and added CLI commands:

- `ast parse-dir D:\atoms\projects\git ..\..\output\git.csv` to parse the whole dir and save to `git.csv`
-  `ast parse-file D:\atoms\projects\git\trace.c ..\..\output\res` to parse just one file

Also omplemented `extract_subtrees` without recursion, prevent maximum recursion depth exceeded errors.

I think that we'll need to parse headers too, but I did not add that to this PR since that would make it difficult to compare performance with the code that is on main.